### PR TITLE
Miscellaneous changes to CI build

### DIFF
--- a/.github/workflows/build-on-tag.yml
+++ b/.github/workflows/build-on-tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout code
@@ -32,8 +32,13 @@ jobs:
             -configuration Release \
             -derivedDataPath build
 
-      - name: Upload .app bundle as artifact
+      - name: Zip .app bundle
+        run: |
+          cd build/Build/Products/Release
+          zip -r MartyDetector.app.zip MartyDetector.app
+
+      - name: Upload zipped .app bundle
         uses: actions/upload-artifact@v4
         with:
-          name: MartyDetector
-          path: build/Build/Products/Release/MartyDetector.app
+          name: MartyDetector-App
+          path: build/Build/Products/Release/MartyDetector.app.zip

--- a/Project.swift
+++ b/Project.swift
@@ -22,7 +22,7 @@ let project = Project(
                 .sdk(name: "c++", type: .library, status: .required),
                 .sdk(name: "OpenCL", type: .framework, status: .required),
                 .sdk(name: "Accelerate", type: .framework, status: .required)
-            ],
+            ]
         ),
     ]
 )


### PR DESCRIPTION
At first, build on CI was failing due to syntax error that only happened on CI.

Secondly, updating the runner version to macos-15 in order to match the
currently installed on developer machine.

Thirdly, adding a zip step after build so the downloaded artifacts have a proper
structure (otherwise the main .app folder was missing after unzipping).
